### PR TITLE
update kuberay dockerfile for konflux

### DIFF
--- a/ray-operator/Dockerfile.konflux
+++ b/ray-operator/Dockerfile.konflux
@@ -16,6 +16,7 @@ RUN go mod download
 COPY main.go main.go
 COPY apis/ apis/
 COPY controllers/ controllers/
+COPY pkg/features pkg/features
 
 # Build
 USER root


### PR DESCRIPTION
this is to fix the following error in konflux pipeline for this component:

```
[1/2] STEP 11/11: RUN . /cachi2/cachi2.env && CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -tags strictfipsruntime -a -o manager main.go controllers/ray/raycluster_controller.go:22:2: no required module provides package github.com/ray-project/kuberay/ray-operator/pkg/features; to add it: go get github.com/ray-project/kuberay/ray-operator/pkg/features
```