### PR TITLE
Revert "add more debug info to Dockerfile.konflux as part RHOAIENG-32…

### DIFF
--- a/ray-operator/Dockerfile.konflux
+++ b/ray-operator/Dockerfile.konflux
@@ -8,16 +8,9 @@ USER root
 
 COPY go.mod go.mod
 COPY go.sum go.sum
-
-# remove 2 below lines when https://issues.redhat.com/browse/RHOAIENG-32231 is resolved
-RUN cat go.mod
-RUN cat go.sum
-
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
-
-# remove '-x' when https://issues.redhat.com/browse/RHOAIENG-32231 is resolved
-RUN go mod download -x
+RUN go mod download
 
 # Copy the go source
 COPY main.go main.go


### PR DESCRIPTION
…231"

This reverts commit 8dec0c24e8090b22047b2798977e04aad4b21ba3.

TBD is kuberay component team needs to
update go.sum files in upstream for the Internal
Konflux builds to pass every time.

https://issues.redhat.com/browse/RHOAIENG-32231

<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
