### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for odh-kuberay-operator-controller-v2-20

### DIFF
--- a/ray-operator/Dockerfile.konflux
+++ b/ray-operator/Dockerfile.konflux
@@ -31,7 +31,8 @@ USER 65532:65532
 
 ENTRYPOINT ["/manager"]
 LABEL com.redhat.component="odh-kuberay-operator-controller-container" \
-      name="managed-open-data-hub/odh-kuberay-operator-controller-container-rhel8" \
+      name="rhoai/odh-kuberay-operator-controller-rhel8" \
+      cpe="cpe:/a:redhat:openshift_ai:2.20::el8" \
       description="Manages lifecycle of RayClusters, RayJobs, RayServices and associated Kubernetes resources" \
       summary="odh-kuberay-operator-controller-container" \
       maintainer="['managed-open-data-hub@redhat.com']" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
