### PR TITLE
Fix/rhoaieng 61483 auth controller deadlock resilience 3.3

### DIFF
--- a/ray-operator/controllers/ray/authentication_controller.go
+++ b/ray-operator/controllers/ray/authentication_controller.go
@@ -25,6 +25,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -40,6 +41,12 @@ import (
 const (
 	// MediumRequeueDelay for ongoing rollouts
 	MediumRequeueDelay = 10 * time.Second
+
+	// SafetyRequeueDelay provides periodic self-healing if watch events are missed
+	SafetyRequeueDelay = 5 * time.Minute
+
+	// ReconcileTimeout prevents a single reconcile from blocking the worker indefinitely
+	ReconcileTimeout = 60 * time.Second
 
 	// Finalizer for ensuring cleanup of cross-namespace resources (HTTPRoutes)
 	authenticationFinalizer = "ray.io/authentication-resources"
@@ -101,6 +108,9 @@ func NewAuthenticationController(mgr manager.Manager, options RayClusterReconcil
 
 // Reconcile handles authentication-related resources and manages OAuth sidecar injection
 func (r *AuthenticationController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	ctx, cancel := context.WithTimeout(ctx, ReconcileTimeout)
+	defer cancel()
+
 	logger := ctrl.LoggerFrom(ctx).WithName("authentication-controller")
 	logger.Info("Reconciling Authentication", "namespacedName", req.NamespacedName)
 
@@ -154,8 +164,8 @@ func (r *AuthenticationController) Reconcile(ctx context.Context, req ctrl.Reque
 	}
 
 	logger.Info("Successfully reconciled authentication", "cluster", rayCluster.Name)
-	// Don't requeue on success - let watches trigger next reconciliation
-	return ctrl.Result{}, nil
+	// Safety requeue to self-heal if a watch event is missed due to predicate filtering
+	return ctrl.Result{RequeueAfter: SafetyRequeueDelay}, nil
 }
 
 // handleDeletion handles cleanup when a RayCluster is being deleted (finalizer pattern)
@@ -233,6 +243,10 @@ func (r *AuthenticationController) handleOIDCConfiguration(ctx context.Context, 
 	if r.options.IsOpenShift {
 		if err := r.enforceEnableIngressFalseOnOpenShift(ctx, rayCluster, logger); err != nil {
 			return err
+		}
+		// Re-fetch after spec update to get the latest resourceVersion
+		if err := r.Get(ctx, req.NamespacedName, rayCluster); err != nil {
+			return fmt.Errorf("failed to re-fetch after enableIngress update: %w", err)
 		}
 	}
 
@@ -1085,12 +1099,15 @@ func (r *AuthenticationController) SetupWithManager(mgr ctrl.Manager) error {
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).
+		WithOptions(controller.Options{MaxConcurrentReconciles: 3}).
 		// PRIMARY: Watch RayClusters
 		For(&rayv1.RayCluster{}, builder.WithPredicates(rayClusterPredicate)).
 		// OWNED: Watch resources owned by RayClusters
 		Owns(&corev1.ServiceAccount{}).
 		Owns(&corev1.Service{}).
 		Owns(&routev1.Route{}).
+		Owns(&gatewayv1beta1.ReferenceGrant{}).
+		Owns(&gatewayv1beta1.HTTPRoute{}).
 		// // SECONDARY: Watch cluster-wide auth config and map to all RayClusters
 		// Watches(
 		// 	&configv1.Authentication{},

--- a/ray-operator/controllers/ray/authentication_controller.go
+++ b/ray-operator/controllers/ray/authentication_controller.go
@@ -71,6 +71,7 @@ const (
 // resources (ConfigMaps, ServiceAccounts, OpenShift Routes) and manages authentication configurations for Ray clusters on Openshift.
 type AuthenticationController struct {
 	client.Client
+	APIReader  client.Reader
 	Recorder   record.EventRecorder
 	Scheme     *runtime.Scheme
 	RESTMapper meta.RESTMapper
@@ -81,6 +82,7 @@ type AuthenticationController struct {
 func NewAuthenticationController(mgr manager.Manager, options RayClusterReconcilerOptions) *AuthenticationController {
 	return &AuthenticationController{
 		Client:     mgr.GetClient(),
+		APIReader:  mgr.GetAPIReader(),
 		Scheme:     mgr.GetScheme(),
 		RESTMapper: mgr.GetRESTMapper(),
 		Recorder:   mgr.GetEventRecorderFor("authentication-controller"),
@@ -737,13 +739,11 @@ func (r *AuthenticationController) ensureOIDCConfigMap(ctx context.Context, clus
 		},
 	}
 
-	opResult, err := controllerutil.CreateOrUpdate(ctx, r.Client, configMap, func() error {
-		// Set controller reference
+	mutateFn := func() error {
 		if err := controllerutil.SetControllerReference(cluster, configMap, r.Scheme); err != nil {
 			return err
 		}
 
-		// Build ConfigMap data dynamically
 		configYAML := fmt.Sprintf(`
 authorization:
   resourceAttributes:
@@ -756,7 +756,6 @@ authorization:
     resourceName: "%s"
 `, cluster.Name+"-head-svc")
 
-		// Set labels and data
 		if configMap.Labels == nil {
 			configMap.Labels = make(map[string]string)
 		}
@@ -769,7 +768,24 @@ authorization:
 		configMap.Data["config.yaml"] = configYAML
 
 		return nil
-	})
+	}
+
+	opResult, err := controllerutil.CreateOrUpdate(ctx, r.Client, configMap, mutateFn)
+	if errors.IsAlreadyExists(err) {
+		// ConfigMap exists but is not visible to the scoped cache (pre-upgrade, missing label).
+		// Fetch directly from the API server, apply mutations, and update.
+		if getErr := r.APIReader.Get(ctx, client.ObjectKeyFromObject(configMap), configMap); getErr != nil {
+			return fmt.Errorf("failed to get existing unlabeled ConfigMap: %w", getErr)
+		}
+		if mutErr := mutateFn(); mutErr != nil {
+			return fmt.Errorf("failed to mutate existing ConfigMap: %w", mutErr)
+		}
+		if updateErr := r.Client.Update(ctx, configMap); updateErr != nil {
+			return fmt.Errorf("failed to update existing ConfigMap with label: %w", updateErr)
+		}
+		logger.Info("OIDC ConfigMap adopted (added cache label)", "name", configMap.Name)
+		return nil
+	}
 	if err != nil {
 		return fmt.Errorf("failed to create or update OIDC ConfigMap: %w", err)
 	}

--- a/ray-operator/controllers/ray/authentication_controller.go
+++ b/ray-operator/controllers/ray/authentication_controller.go
@@ -775,6 +775,7 @@ authorization:
 			configMap.Labels = make(map[string]string)
 		}
 		configMap.Labels["app"] = "kube-rbac-proxy"
+		configMap.Labels[utils.KubernetesCreatedByLabelKey] = utils.ComponentName
 
 		if configMap.Data == nil {
 			configMap.Data = make(map[string]string)

--- a/ray-operator/controllers/ray/authentication_controller.go
+++ b/ray-operator/controllers/ray/authentication_controller.go
@@ -239,20 +239,6 @@ func (r *AuthenticationController) handleOIDCConfiguration(ctx context.Context, 
 		return nil
 	}
 
-	// On OpenShift, enforce enableIngress: false for Gateway-only access
-	// This handles both new clusters (webhook sets it) and existing clusters (upgrade scenario)
-	// HTTPRoute creation is independent of enableIngress
-	// enableIngress controls basic Route/Ingress creation (which may be disabled by webhooks in ODH)
-	if r.options.IsOpenShift {
-		if err := r.enforceEnableIngressFalseOnOpenShift(ctx, rayCluster, logger); err != nil {
-			return err
-		}
-		// Re-fetch after spec update to get the latest resourceVersion
-		if err := r.Get(ctx, req.NamespacedName, rayCluster); err != nil {
-			return fmt.Errorf("failed to re-fetch after enableIngress update: %w", err)
-		}
-	}
-
 	// Add finalizer to ensure cleanup happens before cluster deletion
 	if !controllerutil.ContainsFinalizer(rayCluster, authenticationFinalizer) {
 		logger.Info("Adding authentication finalizer to RayCluster", "cluster", rayCluster.Name)
@@ -1049,46 +1035,6 @@ func (r *AuthenticationController) cleanupOrphanedReferenceGrant(ctx context.Con
 		logger.Info("ReferenceGrant not orphaned (clusters with auth exist)",
 			"namespace", namespace,
 			"authClusters", authClustersCount)
-	}
-
-	return nil
-}
-
-// enforceEnableIngressFalseOnOpenShift ensures enableIngress is set to false on OpenShift
-// This provides upgrade idempotency - handles existing clusters that weren't processed by webhook
-// The webhook sets this for new/edited clusters, this handles clusters from before the webhook was updated
-// Placed in Authentication controller because HTTPRoute requires Gateway access (not basic Routes)
-func (r *AuthenticationController) enforceEnableIngressFalseOnOpenShift(ctx context.Context, rayCluster *rayv1.RayCluster, logger logr.Logger) error {
-	// Check if enableIngress is already false
-	if rayCluster.Spec.HeadGroupSpec.EnableIngress != nil && !*rayCluster.Spec.HeadGroupSpec.EnableIngress {
-		return nil // Already false, nothing to do
-	}
-
-	// Need to set to false
-	wasTrue := rayCluster.Spec.HeadGroupSpec.EnableIngress != nil && *rayCluster.Spec.HeadGroupSpec.EnableIngress
-	wasMissing := rayCluster.Spec.HeadGroupSpec.EnableIngress == nil
-
-	logger.Info("Enforcing enableIngress to false on OpenShift (Gateway-only access)",
-		"cluster", rayCluster.Name, "previousValue", rayCluster.Spec.HeadGroupSpec.EnableIngress)
-
-	// Update the cluster spec
-	rayCluster.Spec.HeadGroupSpec.EnableIngress = ptr.To(false)
-	if err := r.Update(ctx, rayCluster); err != nil {
-		logger.Error(err, "Failed to enforce enableIngress to false", "cluster", rayCluster.Name)
-		return err
-	}
-
-	if wasTrue {
-		logger.Info("Overrode user-specified enableIngress from true to false for Gateway-only access",
-			"cluster", rayCluster.Name)
-		r.Recorder.Eventf(rayCluster, corev1.EventTypeNormal,
-			"EnableIngressEnforced",
-			"Set enableIngress to false to enforce Gateway-only access (overrode user value)")
-	} else if wasMissing {
-		logger.Info("Set enableIngress to false for Gateway-only access (was not set)", "cluster", rayCluster.Name)
-		r.Recorder.Eventf(rayCluster, corev1.EventTypeNormal,
-			"EnableIngressSet",
-			"Set enableIngress to false for Gateway-only access")
 	}
 
 	return nil

--- a/ray-operator/controllers/ray/authentication_controller.go
+++ b/ray-operator/controllers/ray/authentication_controller.go
@@ -42,7 +42,9 @@ const (
 	// MediumRequeueDelay for ongoing rollouts
 	MediumRequeueDelay = 10 * time.Second
 
-	// SafetyRequeueDelay provides periodic self-healing if watch events are missed
+	// SafetyRequeueDelay provides periodic re-reconciliation to detect drift in
+	// cross-namespace resources (HTTPRoute, ReferenceGrant) that cannot use owner
+	// references and therefore don't trigger watch-based reconciliation.
 	SafetyRequeueDelay = 5 * time.Minute
 
 	// ReconcileTimeout prevents a single reconcile from blocking the worker indefinitely
@@ -164,7 +166,8 @@ func (r *AuthenticationController) Reconcile(ctx context.Context, req ctrl.Reque
 	}
 
 	logger.Info("Successfully reconciled authentication", "cluster", rayCluster.Name)
-	// Safety requeue to self-heal if a watch event is missed due to predicate filtering
+	// Periodic re-reconcile to detect drift in cross-namespace resources (HTTPRoute,
+	// ReferenceGrant) that lack owner references and won't trigger watch events.
 	return ctrl.Result{RequeueAfter: SafetyRequeueDelay}, nil
 }
 
@@ -1102,21 +1105,14 @@ func (r *AuthenticationController) SetupWithManager(mgr ctrl.Manager) error {
 		WithOptions(controller.Options{MaxConcurrentReconciles: 3}).
 		// PRIMARY: Watch RayClusters
 		For(&rayv1.RayCluster{}, builder.WithPredicates(rayClusterPredicate)).
-		// OWNED: Watch resources owned by RayClusters
+		// OWNED: Watch resources with owner references back to RayClusters.
+		// Note: HTTPRoute and ReferenceGrant are intentionally excluded here because
+		// HTTPRoute is created in platformNamespace (cross-namespace owner refs are impossible)
+		// and ReferenceGrant uses reference-counting cleanup without owner refs.
+		// SafetyRequeueDelay compensates by periodically re-reconciling to detect drift.
 		Owns(&corev1.ServiceAccount{}).
 		Owns(&corev1.Service{}).
 		Owns(&routev1.Route{}).
-		Owns(&gatewayv1beta1.ReferenceGrant{}).
-		Owns(&gatewayv1beta1.HTTPRoute{}).
-		// // SECONDARY: Watch cluster-wide auth config and map to all RayClusters
-		// Watches(
-		// 	&configv1.Authentication{},
-		// 	handler.EnqueueRequestsFromMapFunc(r.mapAuthResourceToRayClusters),
-		// ).
-		// Watches(
-		// 	&configv1.OAuth{},
-		// 	handler.EnqueueRequestsFromMapFunc(r.mapAuthResourceToRayClusters),
-		// ).
 		Named("authentication").
 		Complete(r)
 }

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -301,6 +301,20 @@ func (r *RayClusterReconciler) rayClusterReconcile(ctx context.Context, instance
 		return ctrl.Result{}, nil
 	}
 
+	// On OpenShift, enforce enableIngress: false for Gateway-only access.
+	// Handles pre-existing clusters from before the webhook enforced this on CREATE/UPDATE.
+	if r.options.IsOpenShift {
+		if instance.Spec.HeadGroupSpec.EnableIngress == nil || *instance.Spec.HeadGroupSpec.EnableIngress {
+			logger.Info("Enforcing enableIngress to false on OpenShift (Gateway-only access)",
+				"cluster", instance.Name, "previousValue", instance.Spec.HeadGroupSpec.EnableIngress)
+			instance.Spec.HeadGroupSpec.EnableIngress = ptr.To(false)
+			if err := r.Update(ctx, instance); err != nil {
+				return ctrl.Result{RequeueAfter: DefaultRequeueDuration}, err
+			}
+			return ctrl.Result{RequeueAfter: DefaultRequeueDuration}, nil
+		}
+	}
+
 	reconcileFuncs := []reconcileFunc{
 		r.reconcileAutoscalerServiceAccount,
 		r.reconcileAutoscalerRole,

--- a/ray-operator/main.go
+++ b/ray-operator/main.go
@@ -14,6 +14,7 @@ import (
 	"go.uber.org/zap/zapcore"
 	"gopkg.in/natefinch/lumberjack.v2"
 	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -308,7 +309,8 @@ func cacheSelectors() (map[client.Object]cache.ByObject, error) {
 	selector := labels.NewSelector().Add(*label)
 
 	return map[client.Object]cache.ByObject{
-		&batchv1.Job{}: {Label: selector},
+		&batchv1.Job{}:       {Label: selector},
+		&corev1.ConfigMap{}: {Label: selector},
 	}, nil
 }
 


### PR DESCRIPTION
## Summary

The authentication controller can permanently hang on clusters experiencing HTTP/2 stream errors from the API server. A single blocked API call (Update for finalizer, or CreateOrUpdate for HTTPRoute/ReferenceGrant) deadlocks the controller's only worker goroutine, preventing all RayClusters from progressing past the `AuthenticationReady` gate.

**Root cause:** On multi-tenant clusters, the operator watches all ConfigMaps cluster-wide. Large List responses break HTTP/2 streams (`INTERNAL_ERROR`), poisoning the shared connection pool. The auth controller's API calls then block indefinitely on dead connections. With `MaxConcurrentReconciles: 1` and no context timeout, a single stuck call permanently blocks the entire controller — even across pod restarts.

## Changes

1. **Context timeout (60s) on every reconcile** — Ensures blocked API calls are cancelled rather than hanging indefinitely.

2. **Increased MaxConcurrentReconciles to 3** — One stuck worker no longer blocks all clusters.

3. **Safety requeue (5m) on success** — Periodically re-reconciles to detect drift in cross-namespace resources (HTTPRoute, ReferenceGrant) that lack owner references.

4. **Removed no-op Owns() for HTTPRoute and ReferenceGrant** — These never triggered reconciliation because cross-namespace owner references are impossible (HTTPRoute) and ReferenceGrant uses reference-counting cleanup without owner refs. Updated comments to accurately describe the SafetyRequeueDelay's purpose.

5. **Scoped ConfigMap informer to only kuberay-managed ConfigMaps** — Adds `app.kubernetes.io/created-by=kuberay-operator` label selector to the manager cache (same pattern as Jobs). Eliminates cluster-wide ConfigMap List that triggers HTTP/2 stream errors.

6. **Moved `enforceEnableIngressFalse` from auth controller to RayCluster controller** — The auth controller should not Update RayCluster spec fields; that triggers the mutating webhook and is the primary deadlock vector. The RayCluster controller is the natural owner of spec enforcement — it already handles ingress reconciliation and has configurable concurrency.

## Evidence from customer must-gather

- 1Gi pod, `restartCount: 0`, clean start — auth controller logged "Handling Integrated OAuth" at `16:00:09` then **never logged again** (1h48m silence)
- All other controllers (RayCluster, networkpolicy, mTLS) continued working
- 73 occurrences of `"Failed to watch *v1.ConfigMap: stream error: INTERNAL_ERROR"`
- RayCluster controller continuously reported "Waiting for AuthenticationReady condition"

## Test plan

- [ ] Unit tests pass (`go test ./controllers/ray/...`)
- [ ] Verify auth controller creates ConfigMaps with `app.kubernetes.io/created-by=kuberay-operator` label
- [ ] Verify `enableIngress` enforcement works from the RayCluster controller on upgrade (pre-existing cluster with `enableIngress: true` or nil)
- [ ] Deploy patched operator on customer cluster to confirm auth controller completes and head pods are created
- [ ] E2E: create auth-enabled RayCluster, verify `AuthenticationReady=True` and head pod comes up