### PR TITLE
RHOAIENG-70905: Cherry-pick kube-rbac-proxy image env var fix to rhoai-3.3

### DIFF
--- a/ray-operator/config/manager/manager.yaml
+++ b/ray-operator/config/manager/manager.yaml
@@ -66,8 +66,6 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          - name: RELATED_IMAGE_ODH_KUBE_AUTH_PROXY_IMAGE
-            value: "registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9@sha256:11828cdb31cd9c1e15bc9e31c7e4669daf71c84c028cad2df5dbab68150da273"
           # If not set or set to true, kuberay auto injects an init container waiting for ray GCS.
           # If false, you will need to inject your own init container to ensure ray GCS is up before the ray workers start.
           # Warning: we highly recommend setting to true and let kuberay handle for you.

--- a/ray-operator/config/manager/manager.yaml
+++ b/ray-operator/config/manager/manager.yaml
@@ -66,6 +66,8 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          - name: RELATED_IMAGE_ODH_KUBE_AUTH_PROXY_IMAGE
+            value: "registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9@sha256:11828cdb31cd9c1e15bc9e31c7e4669daf71c84c028cad2df5dbab68150da273"
           # If not set or set to true, kuberay auto injects an init container waiting for ray GCS.
           # If false, you will need to inject your own init container to ensure ray GCS is up before the ray workers start.
           # Warning: we highly recommend setting to true and let kuberay handle for you.

--- a/ray-operator/config/openshift/gateway-env-patch.yaml
+++ b/ray-operator/config/openshift/gateway-env-patch.yaml
@@ -19,3 +19,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        # kube-rbac-proxy sidecar image for authentication controller
+        # Overridden by ODH operator from RELATED_IMAGE_ODH_KUBE_RBAC_PROXY_IMAGE
+        - name: RELATED_IMAGE_ODH_KUBE_RBAC_PROXY_IMAGE
+          value: $(odh-kube-rbac-proxy-image)

--- a/ray-operator/config/openshift/kustomization.yaml
+++ b/ray-operator/config/openshift/kustomization.yaml
@@ -26,6 +26,13 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: data.odh-kuberay-operator-controller-image
+- name: odh-kube-rbac-proxy-image
+  objref:
+    kind: ConfigMap
+    name: ray-config
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.odh-kube-rbac-proxy-image
 
 resources:
 - ray_operator_scc.yaml

--- a/ray-operator/config/openshift/params.env
+++ b/ray-operator/config/openshift/params.env
@@ -1,2 +1,3 @@
 namespace=opendatahub
 odh-kuberay-operator-controller-image=quay.io/opendatahub/kuberay-operator:v1.4.4
+odh-kube-rbac-proxy-image=registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9@sha256:11828cdb31cd9c1e15bc9e31c7e4669daf71c84c028cad2df5dbab68150da273

--- a/ray-operator/controllers/ray/authentication_controller.go
+++ b/ray-operator/controllers/ray/authentication_controller.go
@@ -10,6 +10,8 @@ import (
 	"fmt"
 	"math/big"
 	"net"
+	"os"
+	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -52,11 +54,33 @@ const (
 
 	oauthConfigVolumeName = "oauth-config"
 
-	oidcProxyContainerName  = "kube-rbac-proxy"
-	oidcProxyPortName       = "https"
-	oauthProxyImage         = "registry.redhat.io/openshift4/ose-oauth-proxy:latest"
-	oidcProxyContainerImage = "registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9@sha256:11828cdb31cd9c1e15bc9e31c7e4669daf71c84c028cad2df5dbab68150da273"
+	oidcProxyContainerName = "kube-rbac-proxy"
+	oidcProxyPortName      = "https"
+	oauthProxyImage        = "registry.redhat.io/openshift4/ose-oauth-proxy:latest"
+
+	// defaultOIDCProxyContainerImage is the fallback image used when no RELATED_IMAGE_*
+	// env var is set. Must match an entry in the RHOAI CSV relatedImages so it is
+	// mirrored correctly in disconnected environments.
+	defaultOIDCProxyContainerImage = "registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9@sha256:11828cdb31cd9c1e15bc9e31c7e4669daf71c84c028cad2df5dbab68150da273"
 )
+
+// oidcProxyContainerImage holds the resolved kube-rbac-proxy image. Populated by
+// init() from the operator's env vars so that disconnected installs can override
+// the image via RELATED_IMAGE_ODH_KUBE_AUTH_PROXY_IMAGE (set in manager.yaml and
+// substituted by the deployer from the RHOAI CSV relatedImages at install time).
+var oidcProxyContainerImage = defaultOIDCProxyContainerImage
+
+func init() {
+	for _, envVar := range []string{
+		"RELATED_IMAGE_ODH_KUBE_AUTH_PROXY_IMAGE",
+		"RELATED_IMAGE_OSE_KUBE_RBAC_PROXY_IMAGE",
+	} {
+		if image := strings.TrimSpace(os.Getenv(envVar)); image != "" {
+			oidcProxyContainerImage = image
+			return
+		}
+	}
+}
 
 // AuthenticationController is a completely independent controller that watches authentication-related
 // resources (ConfigMaps, ServiceAccounts, OpenShift Routes) and manages authentication configurations for Ray clusters on Openshift.


### PR DESCRIPTION
## Summary

Cherry-pick of the kube-rbac-proxy image configurable env var fix to the rhoai-3.3 downstream branch, enabling disconnected environments to receive the latest patched image.

## Changes included

Cherry-picks two commits from midstream dev:

1. PR opendatahub-io/kuberay#188 (ffbdb1df): Makes oidcProxyContainerImage configurable via RELATED_IMAGE env vars
2. PR opendatahub-io/kuberay#202 (f3772296): Integrates with the ODH operator image override flow via params.env + kustomize

## Related

- RHOAIENG-70905
- RHOAIENG-63699
- RHOAIENG-63722